### PR TITLE
First Version Classif Mode And Tuning Params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Suggests:
     modeltime,
     timetk, 
     lubridate,
+    stats,
     knitr,
     rmarkdown,
     roxygen2,

--- a/R/00_global_variables.R
+++ b/R/00_global_variables.R
@@ -1,5 +1,5 @@
 utils::globalVariables(
     names = c(
-        "object", "new_data"
+        "object", "new_data", "values"
     )
 )

--- a/R/parsnip-gam_mod.R
+++ b/R/parsnip-gam_mod.R
@@ -46,7 +46,7 @@
 #' @examples 
 #' 
 #' library(tidymodels)
-#' library(gamsnip)
+#' library(modelgam)
 #' library(modeltime)
 #' library(tidyverse)
 #' library(timetk)

--- a/R/parsnip-gam_mod.R
+++ b/R/parsnip-gam_mod.R
@@ -77,9 +77,14 @@
 #' 
 #'  
 #' @export
-gam_mod <- function(mode = "regression") {
+gam_mod <- function(mode = "regression", 
+                    select_features = FALSE,
+                    adjust_deg_free = 1) {
     
-    args <- list()
+    args <- list(
+        select_features = rlang::enquo(select_features),
+        adjust_deg_free = rlang::enquo(adjust_deg_free)
+    )
     
     parsnip::new_model_spec(
         "gam_mod",
@@ -107,7 +112,10 @@ print.gam_mod <- function(x, ...) {
 
 #' @export
 #' @importFrom stats update
-update.gam_mod <- function(object, parameters = NULL,
+update.gam_mod <- function(object,
+                           select_features = FALSE,
+                           adjust_deg_free = 1,
+                           parameters = NULL,
                            fresh = FALSE, ...) {
     
     parsnip::update_dot_check(...)
@@ -117,7 +125,8 @@ update.gam_mod <- function(object, parameters = NULL,
     }
     
     args <- list(
-        
+        select_features = rlang::enquo(select_features),
+        adjust_deg_free = rlang::enquo(adjust_deg_free)
     )
     
     args <- parsnip::update_main_parameters(args, parameters)

--- a/R/parsnip-gam_mod.R
+++ b/R/parsnip-gam_mod.R
@@ -46,7 +46,7 @@
 #' @examples 
 #' 
 #' library(tidymodels)
-#' library(modelgam)
+#' library(gamsnip)
 #' library(modeltime)
 #' library(tidyverse)
 #' library(timetk)
@@ -154,3 +154,4 @@ translate.gam_mod <- function(x, engine = x$engine, ...) {
     
     x
 }
+

--- a/R/parsnip-gam_mod_data.R
+++ b/R/parsnip-gam_mod_data.R
@@ -6,6 +6,7 @@ make_gam_mod <- function() {
 
 make_gam_mod_mgcv_gam <- function() {
     
+    #### REGRESION
     model  = "gam_mod"
     mode   = "regression"
     engine = "gam"
@@ -49,7 +50,136 @@ make_gam_mod_mgcv_gam <- function() {
             func = c(fun = "predict"),
             args = list(
                 object = rlang::expr(object$fit),
+                newdata = rlang::expr(new_data),
+                type = "response"
+            )
+        )
+    )
+    
+    parsnip::set_pred(
+        model  = model,
+        eng    = engine,
+        mode   = mode,
+        type   = "conf_int",
+        value  = list(
+            pre  = NULL,
+            post = function(results, object) {
+                res <-tibble::tibble(.pre_lower = results$fit - 2*results$se.fit,
+                                     .pre_upper = results$fit + 2*results$se.fit)
+            },
+            func = c(fun = "predict"),
+            args = list(
+                object = rlang::expr(object$fit),
+                newdata = rlang::expr(new_data),
+                type = "link",
+                se.fit = TRUE
+            )
+        )
+    )
+    
+    parsnip::set_pred(
+        model  = model,
+        eng    = engine,
+        mode   = mode,
+        type   = "raw",
+        value  = list(
+            pre  = NULL,
+            post = NULL,
+            func = c(fun = "predict"),
+            args = list(
+                object = rlang::expr(object$fit),
                 newdata = rlang::expr(new_data)
+            )
+        )
+    )
+    
+    #### CLASSIFICATION
+    
+    model  = "gam_mod"
+    mode   = "classification"
+    engine = "gam"
+    
+    parsnip::set_model_engine(model = model, mode = mode, eng = engine)
+    parsnip::set_dependency(model = model, eng = engine, pkg = "mgcv")
+    parsnip::set_dependency(model = model, eng = engine, pkg = "modelgam")
+    
+    parsnip::set_encoding(
+        model = model,
+        eng   = engine,
+        mode  = mode,
+        options = list(
+            predictor_indicators = "none",
+            compute_intercept    = FALSE,
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
+        )
+    )
+    
+    parsnip::set_fit(
+        model = model,
+        eng = engine,
+        mode = mode,
+        value = list(
+            interface = "formula",
+            protect = c("formula", "data"),
+            func = c(pkg = "mgcv", fun = "gam"),
+            defaults = list(family = stats::binomial(link = "logit"))
+        )
+    )
+    
+    prob_to_class_2 <- function(x, object){
+        
+            x <- ifelse(x >= 0.5, object$lvl[2], object$lvl[1])
+            unname(x)
+    }
+    
+    parsnip::set_pred(
+        model  = model,
+        eng    = engine,
+        mode   = mode,
+        type   = "class",
+        value  = list(
+            pre  = NULL,
+            post = function(results, object) {
+
+                tbl <-tibble::as_tibble(results) 
+                
+                if (ncol(tbl)==1){
+                        res<-prob_to_class_2(tbl, object) %>% 
+                            tibble::as_tibble() %>% 
+                            stats::setNames("values") %>%
+                            dplyr::mutate(values = as.factor(values))
+                     } else{
+                         res <- tbl %>% 
+                                apply(.,1,function(x) which(max(x)==x)[1])-1 %>% #modify in the future for something more elegant when gets the formula ok
+                                tibble::as_tibble()
+                 }
+                
+            },
+            func = c(fun = "predict"),
+            args = list(
+                object = rlang::expr(object$fit),
+                newdata = rlang::expr(new_data),
+                type = "response"
+            )
+        )
+    )
+    
+    parsnip::set_pred(
+        model  = model,
+        eng    = engine,
+        mode   = mode,
+        type   = "prob",
+        value  = list(
+            pre  = NULL,
+            post = function(results, object) {
+                res <-tibble::as_tibble(results)
+            },
+            func = c(fun = "predict"),
+            args = list(
+                object = rlang::expr(object$fit),
+                newdata = rlang::expr(new_data),
+                type = "response"
             )
         )
     )

--- a/R/parsnip-gam_mod_data.R
+++ b/R/parsnip-gam_mod_data.R
@@ -15,6 +15,26 @@ make_gam_mod_mgcv_gam <- function() {
     parsnip::set_dependency(model = model, eng = engine, pkg = "mgcv")
     parsnip::set_dependency(model = model, eng = engine, pkg = "modelgam")
     
+    #Args
+    
+    parsnip::set_model_arg(
+        model        = "gam_mod",
+        eng          = "gam",
+        parsnip      = "select_features",
+        original     = "select",
+        func         = list(pkg = "modelgam", fun = "select_features"),
+        has_submodel = FALSE
+    )
+    
+    parsnip::set_model_arg(
+        model        = "gam_mod",
+        eng          = "gam",
+        parsnip      = "adjust_deg_free",
+        original     = "gamma",
+        func         = list(pkg = "modelgam", fun = "adjust_deg_free"),
+        has_submodel = FALSE
+    )
+    
     parsnip::set_encoding(
         model = model,
         eng   = engine,

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,12 @@
 library(testthat)
 library(modelgam)
+library(rsample)
+library(modeltime)
+library(dplyr)
+library(tidyr)
+library(timetk)
+library(lubridate)
+library(rsample)
+library(stats)
 
 test_check("modelgam")

--- a/tests/testthat/test-algo-gam_mod.R
+++ b/tests/testthat/test-algo-gam_mod.R
@@ -1,0 +1,110 @@
+testthat::context("TEST gam_mod: GAM")
+
+# SETUP---
+
+m750_extended <- m750 %>%
+    group_by(id) %>%
+    future_frame(.length_out = 24, .bind_data = TRUE) %>%
+    mutate(lag_24 = lag(value, 24)) %>%
+    ungroup() %>%
+    mutate(date_num = as.numeric(date)) %>%
+    mutate(date_month = month(date))
+
+m750_train  <- m750_extended %>% drop_na()
+m750_future <- m750_extended %>% filter(is.na(value))
+
+classif_df <- readRDS(url("https://github.com/noamross/gams-in-r-course/raw/master/csale.rds"))
+
+classif_split <- initial_split(classif_df, prop = 0.8, strata = purchase)
+
+#Regression ----
+
+model_spec_reg <- gam_mod() %>%
+                  set_engine("gam", family = gaussian(), method = "REML")
+
+model_spec_clas <- gam_mod(mode = "classification") %>%
+                   set_engine("gam", family = binomial(), method = "REML")
+                   
+                   
+
+
+# PARSNIP ----
+
+test_that("gam_mod: Regression Parsnip Test", {
+    
+    testthat::skip_on_cran()
+    
+    model_fit <<- model_spec_reg %>%
+        fit(value ~ s(date_month, k = 12), data = m750_train)
+    
+    predictions_tbl <- model_fit %>%
+        modeltime_calibrate(m750_future) %>%
+        modeltime_forecast(new_data = m750_future)
+    
+    # $fit
+    testthat::expect_s3_class(model_fit$fit, "gam")
+    testthat::expect_s3_class(model_fit, "model_fit")
+    testthat::expect_equal(model_fit$fit$family$family, "gaussian")
+    
+    # $preproc
+    testthat::expect_equal(model_fit$preproc$y_var, "value")
+    
+    
+    # Structure
+    testthat::expect_identical(nrow(m750_future), nrow(predictions_tbl))
+    testthat::expect_identical(m750_future$date, predictions_tbl$.index)
+    
+    # Out-of-Sample Accuracy Tests
+    
+    resid <- model_fit$fit$residuals
+    
+    # - Max Error less than 2000
+    testthat::expect_lte(max(abs(resid)), 2000)
+    
+    # - MAE less than 1200
+    testthat::expect_lte(mean(abs(resid)), 1200)
+    
+})
+
+
+test_that("gam_mod: Classification Parsnip Test", {
+    
+    testthat::skip_on_cran()
+    
+    model_fit <<- model_spec_clas %>%
+        fit(as.factor(purchase) ~ s(mortgage_age, k = 12), data = training(classif_split))
+    
+    
+    predictions_prob_tbl <- model_fit %>%
+        predict(testing(classif_split), type = "prob")
+    
+    predictions_class_tbl <- model_fit %>%
+        predict(testing(classif_split), type = "class")
+    
+    # $fit
+    testthat::expect_s3_class(model_fit$fit, "gam")
+    testthat::expect_s3_class(model_fit, "model_fit")
+    testthat::expect_equal(model_fit$fit$family$family, "binomial")
+    testthat::expect_equal(model_fit$lvl, c("0", "1"))
+    
+    # $preproc
+    testthat::expect_equal(model_fit$preproc$y_var, "purchase")
+    
+    
+    # Structure
+    testthat::expect_identical(nrow(predictions_prob_tbl), nrow(predictions_class_tbl))
+    testthat::expect_identical(nrow(predictions_prob_tbl), nrow(testing(classif_split)))
+    testthat::expect_identical(levels(predictions_class_tbl$.pred_class), "0")
+    
+    # Out-of-Sample Accuracy Tests
+    
+    resid <- model_fit$fit$residuals
+    
+    # - Max Error less than 6
+    testthat::expect_lte(max(abs(resid)), 6)
+    
+    # - MAE less than 2
+    
+    testthat::expect_lte(mean(abs(resid)), 2)
+    
+})

--- a/tests/testthat/test-blah.R
+++ b/tests/testthat/test-blah.R
@@ -1,3 +1,0 @@
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
-})


### PR DESCRIPTION
Hi @mdancho84 

I closed the previous PR in order to send you this one with the updates of the parameters mentioned by Max added to the previous one. I copy what I had written:

"
Hi @mdancho84 ,

I have created the first version of the binary classification and have been testing to extend it to more categories from the multinom() family but have not been able to. I think we should open an issue in parsnip to see how we can make that kind of structures pass through parsnip::fit().

```
Example:

mpg <- ggplot2::mpg
mpg$cyl <- as.numeric(as.factor(mpg$cyl))-1

mgcv::gam(list(cyl ~ s(cty), ~ s(cty), ~s(cty)), 
          family = multinom(K=3), 
          data = mpg)
```

I have also put some tests for both regression and classification and I have added in the description in suggestions the stats package, as it is the one that contains many of the families that will be used for modeling.
"